### PR TITLE
Introduce PVC based repo-host for pgbackrest

### DIFF
--- a/manifests/postgresql.crd.yaml
+++ b/manifests/postgresql.crd.yaml
@@ -800,6 +800,7 @@ spec:
                                 - "s3"
                                 - "gcs"
                                 - "azure"
+                                - "pvc"
                             resource:
                               type: string
                             endpoint:
@@ -815,6 +816,8 @@ spec:
                                   type: string
                                 diff:
                                   type: string
+                            Pvcsize:
+                              type: string
                           required:
                           - name
                           - storage

--- a/pkg/apis/cpo.opensource.cybertec.at/v1/crds.go
+++ b/pkg/apis/cpo.opensource.cybertec.at/v1/crds.go
@@ -1151,7 +1151,7 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 										Items: &apiextv1.JSONSchemaPropsOrArray{
 											Schema: &apiextv1.JSONSchemaProps{
 												Type:     "object",
-												Required: []string{"name", "storage", "resource"},
+												Required: []string{"name", "storage"},
 												Properties: map[string]apiextv1.JSONSchemaProps{
 													"name": {
 														Type:    "string",
@@ -1168,6 +1168,9 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 															},
 															{
 																Raw: []byte(`"azure"`),
+															},
+															{
+																Raw: []byte(`"pvc"`),
 															},
 														},
 													},
@@ -1193,6 +1196,9 @@ var PostgresCRDResourceValidation = apiextv1.CustomResourceValidation{
 																Type: "string",
 															},
 														},
+													},
+													"pvcsize": {
+														Type: "string",
 													},
 												},
 											},

--- a/pkg/apis/cpo.opensource.cybertec.at/v1/postgresql_type.go
+++ b/pkg/apis/cpo.opensource.cybertec.at/v1/postgresql_type.go
@@ -95,6 +95,7 @@ type PostgresSpec struct {
 	Backup                  *Backup        `json:"backup,omitempty"`
 	TDE                     *TDE           `json:"tde,omitempty"`
 	Monitoring              *Monitoring    `json:"monitor,omitempty"`
+	RepoHost                bool           `json:"Repohost,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
@@ -288,6 +289,7 @@ type Repo struct {
 	Endpoint string            `json:"endpoint"`
 	Region   string            `json:"region"`
 	Schedule map[string]string `json:"schedule"`
+	PvcSize  string            `json:"pvcsize"`
 }
 
 type Restore struct {

--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -630,7 +630,25 @@ func (c *Cluster) createPgbackrestRestoreConfig() (err error) {
 	if err != nil {
 		return fmt.Errorf("could not generate pgbackrest restore configmap spec: %v", err)
 	}
-	c.logger.Debugf("Generated pgbackrest configmapSpec: %v", pgbackrestRestoreConfigmapSpec)
+	c.logger.Debugf("Generated pgbackrest restore configmapSpec: %v", pgbackrestRestoreConfigmapSpec)
+
+	_, err = c.KubeClient.ConfigMaps(c.Namespace).Create(context.TODO(), pgbackrestRestoreConfigmapSpec, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("could not create pgbackrest restore config: %v", err)
+	}
+
+	return nil
+}
+
+func (c *Cluster) createPgbackrestRepohostConfig() (err error) {
+
+	c.setProcessName("creating a configmap for pgbackrest repo-host")
+
+	pgbackrestRestoreConfigmapSpec, err := c.generatePgbackrestRepoHostConfigmap()
+	if err != nil {
+		return fmt.Errorf("could not generate pgbackrest repo-host configmap spec: %v", err)
+	}
+	c.logger.Debugf("Generated pgbackrest restore configmapSpec: %v", pgbackrestRestoreConfigmapSpec)
 
 	_, err = c.KubeClient.ConfigMaps(c.Namespace).Create(context.TODO(), pgbackrestRestoreConfigmapSpec, metav1.CreateOptions{})
 	if err != nil {


### PR DESCRIPTION
With this commit a PVC based backup is possible for pgbackrest. This can be done by providing Spec.Backup.Pgbackrest.Repo[i].Storage = "pvc" in the manifest, this will also require to provide Spec.Backup.Pgbackrest.Repo[i].pvcSize = 'xGi'. When this is option is set, a statefulset with 1 instance is created for the repo-host. The required global and db section for the pgbackrest configuration file pgbackrest_instance.conf should be set by the appropriate configmaps for both the postgres pods and the repo-host pod.