### PR TITLE
Create user when adding monitoring container

### DIFF
--- a/pkg/cluster/resources.go
+++ b/pkg/cluster/resources.go
@@ -15,6 +15,7 @@ import (
 
 	cpov1 "github.com/cybertec-postgresql/cybertec-pg-operator/pkg/apis/cpo.opensource.cybertec.at/v1"
 	"github.com/cybertec-postgresql/cybertec-pg-operator/pkg/util"
+	"github.com/cybertec-postgresql/cybertec-pg-operator/pkg/util/constants"
 	"github.com/cybertec-postgresql/cybertec-pg-operator/pkg/util/k8sutil"
 	"github.com/cybertec-postgresql/cybertec-pg-operator/pkg/util/retryutil"
 )
@@ -94,6 +95,16 @@ func (c *Cluster) createStatefulSet() (*appsv1.StatefulSet, error) {
 			Env: c.generateMonitoringEnvVars(),
 		}
 		c.Spec.Sidecars = append(c.Spec.Sidecars, *sidecar) //populate the sidecar spec so that the sidecar is automatically created
+
+		//Add monitoring user
+		flg := cpov1.UserFlags{constants.RoleFlagLogin}
+		if c.Spec.Users != nil {
+			c.Spec.Users[monitorUsername] = flg
+		} else {
+			users := make(map[string]cpov1.UserFlags)
+			c.Spec.Users = users
+			c.Spec.Users[monitorUsername] = flg
+		}
 	}
 
 	statefulSetSpec, err := c.generateStatefulSet(&c.Spec)

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -1703,7 +1703,7 @@ func (c *Cluster) createMonitoringSecret() error {
 		},
 		Type: v1.SecretTypeOpaque,
 		Data: map[string][]byte{
-			"username": []byte(c.getMonitoringSecretName()),
+			"username": []byte(monitorUsername),
 			"password": []byte(fmt.Sprintf("%x", generatedKey)),
 		},
 	}

--- a/pkg/cluster/sync.go
+++ b/pkg/cluster/sync.go
@@ -521,6 +521,16 @@ func (c *Cluster) syncStatefulSet() error {
 			Env: c.generateMonitoringEnvVars(),
 		}
 		c.Spec.Sidecars = append(c.Spec.Sidecars, *sidecar) //populate the sidecar spec so that the sidecar is automatically created
+
+		//Add monitoring user
+		flg := cpov1.UserFlags{constants.RoleFlagLogin}
+		if c.Spec.Users != nil {
+			c.Spec.Users[monitorUsername] = flg
+		} else {
+			users := make(map[string]cpov1.UserFlags)
+			c.Spec.Users = users
+			c.Spec.Users[monitorUsername] = flg
+		}
 	}
 	// NB: Be careful to consider the codepath that acts on podsRollingUpdateRequired before returning early.
 	sset, err := c.KubeClient.StatefulSets(c.Namespace).Get(context.TODO(), c.statefulSetName(), metav1.GetOptions{})


### PR DESCRIPTION
When monitoring is created in sync, add the respective user.