### PR TITLE
Fix values.yaml field name to match CRD specification

### DIFF
--- a/charts/postgres-operator/values.yaml
+++ b/charts/postgres-operator/values.yaml
@@ -207,7 +207,7 @@ configKubernetes:
   # spilo_fsgroup: 103
   
   # whether the containers should run with readonly_root_filesystem
-  readonly_root_filesystem: true
+  container_readonly_root_filesystem: true
   # whether the Spilo container should run in privileged mode
   spilo_privileged: false
   # whether the Spilo container should run with additional permissions other than parent.


### PR DESCRIPTION
## Summary
- Fixed incorrect field name in `values.yaml` to match the CRD specification
- Changed `readonly_root_filesystem` to `container_readonly_root_filesystem`

## Details
The `values.yaml` file referenced `readonly_root_filesystem`, but the actual field name in the OperatorConfiguration CRD is `container_readonly_root_filesystem`. This mismatch could cause configuration issues when the chart is deployed.

## Changes
- Updated field name in `charts/postgres-operator/values.yaml` from `readonly_root_filesystem` to `container_readonly_root_filesystem`

## Testing
- Verified [field name matches #L342](https://github.com/cybertec-postgresql/CYBERTEC-pg-operator/blob/main/charts/postgres-operator/crds/operatorconfigurations.yaml#L342) the CRD definition in `charts/postgres-operator/crds/operatorconfigurations.yaml`